### PR TITLE
Fix saving term with a default archive causes broken term page

### DIFF
--- a/post-type-archive-mapping.php
+++ b/post-type-archive-mapping.php
@@ -414,7 +414,7 @@ class PostTypeArchiveMapping {
 						'selected'          => esc_attr( $selection ),
 						'name'              => esc_html( "post-type-archive-mapping[{$post_type}]" ),
 						'value_field'       => 'ID',
-						'option_none_value' => esc_html__( 'Default', 'post-type-archive-mapping' ),
+						'option_none_value' => 'default',
 						'show_option_none'  => esc_html__( 'Default', 'post-type-archive-mapping' ),
 					)
 				);


### PR DESCRIPTION
The `pre_get_posts` compares the `_term_archive_mapping` value to lowercased `default` and thus ends up passing through to the custom archive mapping when the value is capitalized.