### PR TITLE
replace deprecated block_categories filter with block_categories_all

### DIFF
--- a/includes/admin/class-gutenberg.php
+++ b/includes/admin/class-gutenberg.php
@@ -16,7 +16,7 @@ class Gutenberg {
 	 * Class initializer.
 	 */
 	public function run() {
-		add_filter( 'block_categories', array( $this, 'add_block_category' ), 10, 2 );
+		add_filter( 'block_categories_all', array( $this, 'add_block_category' ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
see [https://developer.wordpress.org/reference/hooks/block_categories/](https://developer.wordpress.org/reference/hooks/block_categories/)